### PR TITLE
Add basic React front-end

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # naughtycamboss
-Affiliate Cam Model SIte
+
+A simple React front-end inspired by camsharks.com.
+
+## Development
+
+This project uses CDN-hosted React and Babel for quick setup. To run the site locally you need Node.js installed.
+
+Install dependencies (only `serve` is required for the dev server):
+
+```bash
+npm install serve
+```
+
+Start the server:
+
+```bash
+npm start
+```
+
+Then open <http://localhost:3000> in your browser.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "naughtycamboss",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "npx serve public -l 3000"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Naughty Cam Boss</title>
+    <link rel="stylesheet" href="style.css">
+    <script crossorigin src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+    <script type="text/babel" src="../src/index.js"></script>
+</body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,34 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f8f8f8;
+}
+header {
+    background-color: #2c3e50;
+    color: #fff;
+    padding: 20px;
+    text-align: center;
+}
+main {
+    padding: 20px;
+}
+.model-card {
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 15px;
+    margin-bottom: 20px;
+}
+.model-card img {
+    width: 100%;
+    height: auto;
+    border-radius: 4px;
+}
+.model-card h3 {
+    margin: 10px 0 5px;
+}
+.model-card p {
+    margin: 0;
+    color: #555;
+}

--- a/src/App.js
+++ b/src/App.js
@@ -1,0 +1,32 @@
+function ModelCard({ model }) {
+    return (
+        <div className="model-card">
+            <img src={model.image} alt={model.name} />
+            <h3>{model.name}</h3>
+            <p>{model.description}</p>
+        </div>
+    );
+}
+
+function App() {
+    const models = [
+        { name: 'Samantha', image: 'https://placekitten.com/300/200', description: 'Fun and flirty brunette.' },
+        { name: 'Ashley', image: 'https://placekitten.com/300/201', description: 'Energetic redhead who loves to chat.' },
+        { name: 'Jade', image: 'https://placekitten.com/300/202', description: 'Sultry blonde with a playful attitude.' },
+    ];
+
+    return (
+        <div>
+            <header>
+                <h1>Naughty Cam Boss</h1>
+                <p>Explore live cam models</p>
+            </header>
+            <main>
+                {models.map(model => (
+                    <ModelCard key={model.name} model={model} />
+                ))}
+            </main>
+        </div>
+    );
+}
+export default App;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,5 @@
+import App from "./App";
+ReactDOM.render(
+    <App />,
+    document.getElementById('root')
+);


### PR DESCRIPTION
## Summary
- create a simple React setup using CDN builds
- add model card components and basic styling
- provide package.json with a `start` script
- update README with instructions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685df18096608326b2ca32147ae1700e